### PR TITLE
fix: coap-viewer cannot receive data

### DIFF
--- a/CoapBroker.md
+++ b/CoapBroker.md
@@ -1,8 +1,8 @@
-# WebSocket Broker Servers
+# Coap Broker Servers
 
 [![Join the chat at https://gitter.im/wotcity/wotcity-wot-framework](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/wotcity/wotcity-wot-framework?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-A WebSocket broker server is not running on IoT devices. The main use case is for constrained devices (eg. microcontrollers) to send data streams over the web.
+A Coap broker server is not running on IoT devices. The main use case is for constrained devices (eg. microcontrollers) to send data streams over the web.
 
 1. [Install](#install)
 2. [Usage](#usage)
@@ -14,9 +14,9 @@ A WebSocket broker server is not running on IoT devices. The main use case is fo
 1. [Download dotcity-wot-framework](https://github.com/wotcity/dotcity-wot-framework).
 2. Run `$ cd dotcity-wot-framework` to change the directory.
 3. Run `$ npm install` to install the dependencies if you don't already have them.
-4. Run `$ node servers/websocket-broker.js` to start the WoT websocket server.
+4. Run `$ node servers/coap-broker.js` to start the WoT Coap server.
 
-By default, the server is running at `ws://localhost:8000`. You could override the default settings by Linux shell environment varialbes ```HOST``` and ```PORT```. To start WebSocket broker server at *wotcity.com* and port 8080, run `$ export HOST=wotcity.com; export PORT=8080; node servers/websocket-broker.js` .
+By default, the server is running at `coap://localhost:8000`. You could override the default settings by Linux shell environment varialbes ```HOST``` and ```PORT```. To start Coap broker server at *wotcity.com* and port 8080, run `$ export HOST=wotcity.com; export PORT=8080; node servers/coap-broker.js` .
 
 ### Prerequisites
 
@@ -27,34 +27,34 @@ By default, the server is running at `ws://localhost:8000`. You could override t
 To send the data over the Internet, IoT devices should use the url below to establish a connection with the server.
 
 ```
-ws://[hostname]/object/[name]/send
+coap://[hostname]/object/[name]/send
 ```
 
 You must specify an object name and your hostname. For example:
 
 ```
-ws://localhost:8000/object/frontdoor/send
+coap://localhost:8000/object/frontdoor/send
 ```
 
 To receive data from the server, the frontend should use the url below to establish a connection with the server.
 
 ```
-ws://localhost:8000/object/[name]/viewer
+coap://localhost:8000/object/[name]/viewer
 ```
 
 Also, you need to specify the object name and hostname. For example:
 
 ```
-ws://localhost:8000/object/frontdoor/viewer
+coap://localhost:8000/object/frontdoor/viewer
 ```
 
-An physical object has two significant resources, *send* and *viewer*. *send* is to send device data to the server over Websocket connection. *viewer* could be used by web frontend to receive real-time data over the connection.
+An physical object has two significant resources, *send* and *viewer*. *send* is to send device data to the server over Coap connection. *viewer* could be used by web frontend to receive real-time data over the connection.
 
 ### Tests
 
 1. Open a new terminal and run `$ cd tests` to enter the directory of test scripts.
-2. Run `$ node websocket-send.js` to start sending streaming data to WoT websocket server.
-3. Open a new terminal and run `$ node websocket-viewer.js` to start receiving streaming data over websocket. 
+2. Run `$ node coap-send.js` to start sending streaming data to WoT coap server.
+3. Open a new terminal and run `$ node coap-view.js` to start receiving streaming data over coap. 
 
 ## Discussion
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ Please use [Devify CLI](https://github.com/DevifyPlatform/devify-cli) to speed u
 
 ## Install and Usage
 
-* [Install and Run Broker Servers](WebSocketBroker.md)
+* [Install and Run Websocket Broker Servers](WebSocketBroker.md)
+* [Install and Run Coap Broker Servers](CoapBroker.md)
 
 ## Discussion
 

--- a/lib/coapServer/requestHandlers.js
+++ b/lib/coapServer/requestHandlers.js
@@ -90,7 +90,7 @@ Handlers.viewer = function(pathname, connection, clients) {
   // Save viewer clients (unlimited clients)
   for (var path in clients) {
       if (path === pathname) {
-          return clients[path].push(connection.responsive);
+          return clients[path].push(connection.response);
       }
   }
 
@@ -98,7 +98,7 @@ Handlers.viewer = function(pathname, connection, clients) {
    * Not found. There is not a existing sender.
    */
   clients[pathname] = [];
-  clients[pathname].push(connection.responsive);
+  clients[pathname].push(connection.response);
 }
 
 /**

--- a/tests/coap-view-data.js
+++ b/tests/coap-view-data.js
@@ -1,6 +1,11 @@
 var coap = require('coap');
 
-var clientWriable = coap.request('coap://127.0.0.1:8000/object/5550937980d51931b3000009/viewer');
+var clientWriable = coap.request({
+	'hostname': '127.0.0.1',
+	'port': 8000,
+	'pathname': '/object/5550937980d51931b3000009/viewer',
+	'observe': true
+});
 
 clientWriable.on('response', function(res) {
     res.pipe(process.stdout)


### PR DESCRIPTION
Here is an error message shown in coap-broker terminal once a coap-viewer connects to.

> /wotcity-wot-framework/lib/coapServer/server.js:97
    connections[i].write(data);
                        ^
> TypeError: Cannot read property 'write' of undefined

**Fixed and make a pull request. :)**