### PR TITLE
persist data before coap-proxy-websocket connection established

### DIFF
--- a/lib/coapServer/requestHandlers.js
+++ b/lib/coapServer/requestHandlers.js
@@ -134,7 +134,7 @@ Handlers.proxyingHTTP = function(pathname, connection, clients) {
  * The CoAP Proxy to WebSocket Endpoint
  */
 var webSocketConnections = [];
-
+var proxyBuffer = bl();
 Handlers.proxyingWebSocket = function(pathname, connection, clients) {
   var request = connection.request;
   var wsConn = webSocketConnections[pathname];
@@ -170,22 +170,23 @@ Handlers.proxyingWebSocket = function(pathname, connection, clients) {
     console.log('Connect to endpoint ' + uri);
 
     // initial websocket connection
-    return wsClient.connect(uri, '');
+    wsClient.connect(uri, '');
   }
 
   // there is an normal websocket client of this client connection
   // start dispatch coap message
-  var stream = bl();
-
   request.on('data', function(chunk) {
-    stream.append(chunk);
+    proxyBuffer.append(chunk);
   });
 
   // websocket sender
   request.on('end', function() {
-    var data = stream.toString('ascii');
+    if (typeof(wsConn) === 'undefined') return;
+    
+    var data = proxyBuffer.toString('ascii');
     wsConn.sendUTF(data);
-
+    proxyBuffer = bl();
+    
     // emit 'onData'
     server.emit('data', {
       data: data,


### PR DESCRIPTION
In first run-up of coap-proxy-websocket case, the first data sent from coap-sender is always **NOT** received by websocket-viewer. Make a pull-request to have an `proxyBuffer` to persist data before connection of coap-proxy-websocket is established.